### PR TITLE
Download links updated to v0.17.2 for Ludo and v1.0-beta6 for LudOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
         <p><img id="logo" src="ludo.png" alt="Ludo"></p>
         <h1>Ludo is a minimalist frontend for emulators</h1>
         <div class="download">
-          <a href="https://github.com/libretro/ludo/releases/download/v0.17.1/Ludo-Windows-x86_64-0.17.1.zip" class="btn btn-outline-primary">Download for Windows</a>
-          <a href="https://github.com/libretro/ludo/releases/download/v0.17.1/Ludo-OSX-x86_64-0.17.1.dmg" class="btn btn-outline-primary">Download for Mac</a>
-          <a href="https://github.com/libretro/ludo/releases/download/v0.17.1/Ludo-Linux-x11-x86_64-0.17.1.tar.gz" class="btn btn-outline-primary">Download for Linux</a>
-          <div class="version text-primary small">Currently v0.17.1 &middot; <a href="https://github.com/libretro/ludo/releases">Changelog</a> &middot; For 64bit systems</div>
+          <a href="https://github.com/libretro/ludo/releases/download/v0.17.2/Ludo-Windows-x86_64-0.17.2.zip" class="btn btn-outline-primary">Download for Windows</a>
+          <a href="https://github.com/libretro/ludo/releases/download/v0.17.2/Ludo-OSX-x86_64-0.17.2.dmg" class="btn btn-outline-primary">Download for Mac</a>
+          <a href="https://github.com/libretro/ludo/releases/download/v0.17.2/Ludo-Linux-x11-x86_64-0.17.2.tar.gz" class="btn btn-outline-primary">Download for Linux</a>
+          <div class="version text-primary small">Currently v0.17.2 &middot; <a href="https://github.com/libretro/ludo/releases">Changelog</a> &middot; For 64bit systems</div>
         </div>
       </div>
     </header>
@@ -92,9 +92,9 @@
               It behaves and looks exactly the same and can be installed directly on a TV Box to recreate a game console experience.<br><br>
   
               <div class="text-center">
-                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta5/LudOS-Generic.x86_64-1.0-beta5.img.gz" class="btn btn-primary">⤓ PC 64bit</a>
-                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta5/LudOS-RPi2.arm-1.0-beta5.img.gz" class="btn btn-primary">⤓ Raspberry Pi 2 / 3</a>
-                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta5/LudOS-RPi4.arm-1.0-beta5.img.gz" class="btn btn-primary">⤓ Raspberry Pi 4</a>
+                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta6/LudOS-Generic.x86_64-1.0-beta6.img.gz" class="btn btn-primary">⤓ PC 64bit</a>
+                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta6/LudOS-RPi2.arm-1.0-beta6.img.gz" class="btn btn-primary">⤓ Raspberry Pi 2 / 3</a>
+                <a href="https://github.com/libretro/LudOS/releases/download/v1.0-beta6/LudOS-RPi4.arm-1.0-beta6.img.gz" class="btn btn-primary">⤓ Raspberry Pi 4</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
However, the MacOS link for Ludo v0.17.2 won't work now, as a compiled version for the target has yet to be released.